### PR TITLE
Update defaults for extensions and exclude list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # GitHub Repo Single Text Exporter
 
-This Chrome extension downloads the current GitHub repository as a ZIP file, extracts text-based files, and combines them into a single file. By default `.py`, `.go`, `.md`, and `.txt` files are included. If `README.md` exists it is placed first, followed by the remaining files in alphabetical order. The list of extensions can be customised from the extension's options page.
+This Chrome extension downloads the current GitHub repository as a ZIP file, extracts text-based files, and combines them into a single file. By default common programming languages are included such as `.py`, `.js`, `.ts`, `.jsx`, `.tsx`, `.go`, `.java`, `.c`, `.cpp`, `.cs`, `.rb`, `.rs`, `.php`, `.kt`, `.swift`, `.sh`, `.md`, and `.txt`. If `README.md` exists it is placed first, followed by the remaining files in alphabetical order. The list of extensions can be customised from the extension's options page.
 
 ## Custom File Extensions
 
-Use the Options page to specify which file extensions should be collected when exporting a repository. Enter one extension per line; if no value is provided the default list (`py`, `go`, `md`, `txt`) is used.
+Use the Options page to specify which file extensions should be collected when exporting a repository. Enter one extension per line; if no value is provided the default list is used (`py`, `js`, `ts`, `jsx`, `tsx`, `go`, `java`, `c`, `cpp`, `cs`, `rb`, `rs`, `php`, `kt`, `swift`, `sh`, `md`, `txt`).
 
 ### Exclude Files
 
-The Options page also lets you specify glob patterns for files to omit from the export. Enter one pattern per line using [minimatch](https://github.com/isaacs/minimatch) syntax.
+The Options page also lets you specify glob patterns for files to omit from the export. By default `.vscode/**`, `.github/**`, `node_modules/**`, `dist/**`, and `build/**` are excluded. Enter one pattern per line using [minimatch](https://github.com/isaacs/minimatch) syntax to customise the list.
 
 Click the extension icon while viewing a GitHub repository to download the text file. The repository is fetched from
 `https://codeload.github.com/<owner>/<repo>/zip/refs/heads/main`, and this URL is logged to the extension's service worker console.

--- a/options.html
+++ b/options.html
@@ -6,10 +6,10 @@
 </head>
 <body>
   <h1>File Extensions</h1>
-  <p>Enter file extensions to include, one per line.</p>
+  <p>Enter file extensions to include, one per line. The default list covers common languages such as <code>py</code>, <code>js</code>, <code>ts</code>, <code>go</code>, <code>java</code> and more.</p>
   <textarea id="exts" rows="6" cols="30"></textarea>
   <h1>Exclude Files</h1>
-  <p>Glob patterns to exclude, one per line.</p>
+  <p>Glob patterns to exclude, one per line. By default <code>.vscode/**</code>, <code>.github/**</code>, <code>node_modules/**</code>, <code>dist/**</code> and <code>build/**</code> are skipped.</p>
   <textarea id="exclude" rows="6" cols="30"></textarea>
   <br />
   <button id="save">Save</button>

--- a/src/background.ts
+++ b/src/background.ts
@@ -60,7 +60,26 @@ chrome.action.onClicked.addListener(async (tab: chrome.tabs.Tab) => {
       'extensions',
       'exclude',
     ]);
-    let exts = ['py', 'go', 'md', 'txt'];
+    let exts = [
+      'py',
+      'js',
+      'ts',
+      'jsx',
+      'tsx',
+      'go',
+      'java',
+      'c',
+      'cpp',
+      'cs',
+      'rb',
+      'rs',
+      'php',
+      'kt',
+      'swift',
+      'sh',
+      'md',
+      'txt',
+    ];
     if (typeof extensions === 'string' && extensions.trim()) {
       exts = extensions
         .split(/\s+/)
@@ -69,7 +88,13 @@ chrome.action.onClicked.addListener(async (tab: chrome.tabs.Tab) => {
     }
     const extRegex = new RegExp(`\.(${exts.map((e) => e.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')).join('|')})$`, 'i');
 
-    let excludeGlobs: string[] = [];
+    let excludeGlobs: string[] = [
+      '.vscode/**',
+      '.github/**',
+      'node_modules/**',
+      'dist/**',
+      'build/**',
+    ];
     if (typeof exclude === 'string' && exclude.trim()) {
       excludeGlobs = exclude
         .split(/\r?\n/)

--- a/src/options.ts
+++ b/src/options.ts
@@ -4,9 +4,13 @@ async function loadOptions() {
     'exclude',
   ]);
   const extArea = document.getElementById('exts') as HTMLTextAreaElement;
-  extArea.value = extensions || 'py\ngo\nmd\ntxt';
+  extArea.value =
+    extensions ||
+    'py\njs\nts\njsx\ntsx\ngo\njava\nc\ncpp\ncs\nrb\nrs\nphp\nkt\nswift\nsh\nmd\ntxt';
   const exArea = document.getElementById('exclude') as HTMLTextAreaElement;
-  exArea.value = exclude || '';
+  exArea.value =
+    exclude ||
+    '.vscode/**\n.github/**\nnode_modules/**\ndist/**\nbuild/**';
 }
 
 async function saveOptions() {


### PR DESCRIPTION
## Summary
- broaden default list of file extensions
- exclude common directories by default
- document new defaults in the README
- explain defaults in the options page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852c121cb908322a7d34d69c59ae42f