### PR TITLE
Fix path handling for ZIP entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Use the Options page to specify which file extensions should be collected when e
 ### Exclude Files
 
 The Options page also lets you specify glob patterns for files to omit from the export. By default `.vscode/**`, `.github/**`, `node_modules/**`, `dist/**`, and `build/**` are excluded. Enter one pattern per line using [minimatch](https://github.com/isaacs/minimatch) syntax to customise the list.
+Paths are matched relative to the repository root and the `file:` sections in the
+output use these same relative paths.
 
 Click the extension icon while viewing a GitHub repository to download the text file. The repository is fetched from
 `https://codeload.github.com/<owner>/<repo>/zip/refs/heads/main`, and this URL is logged to the extension's service worker console.

--- a/src/background.ts
+++ b/src/background.ts
@@ -106,9 +106,10 @@ chrome.action.onClicked.addListener(async (tab: chrome.tabs.Tab) => {
     const entries: Entry[] = [];
     zip.forEach((relativePath: string, zipEntry: any) => {
       if (zipEntry.dir) return;
-      if (!extRegex.test(relativePath)) return;
-      if (excludeGlobs.some((p) => minimatch(relativePath, p))) return;
-      entries.push({ path: relativePath, file: zipEntry });
+      const trimmed = relativePath.replace(/^[^/]+\//, '');
+      if (!extRegex.test(trimmed)) return;
+      if (excludeGlobs.some((p) => minimatch(trimmed, p))) return;
+      entries.push({ path: trimmed, file: zipEntry });
     });
 
     const readmeIndex = entries.findIndex((e) => /(^|\/)README\.md$/i.test(e.path));


### PR DESCRIPTION
## Summary
- strip the root folder from ZIP paths so `file:` sections omit the repository name
- match exclude glob patterns against these relative paths
- document that paths are relative to the repo root

## Testing
- `npm run build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c415688083228256d24b511b7371