### PR TITLE
Handle branch detection and repo info

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Options page also lets you specify glob patterns for files to omit from the 
 Paths are matched relative to the repository root and the `file:` sections in the
 output use these same relative paths.
 
-Click the extension icon while viewing a GitHub repository to download the text file. The repository archive is fetched from the branch shown in the URL if one is present, otherwise the repository's default branch is used. The download URL is logged to the extension's service worker console.
+Click the extension icon while viewing a GitHub repository to download the text file. The repository archive is fetched from the branch shown in the URL if one is present, otherwise the repository's default branch is used. Branch names containing slashes are detected correctly. The download URL is logged to the extension's service worker console.
 
 ## Private Repositories
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Repo Single Text Exporter
 
-This Chrome extension downloads the current GitHub repository as a ZIP file, extracts text-based files, and combines them into a single file. By default common programming languages are included such as `.py`, `.js`, `.ts`, `.jsx`, `.tsx`, `.go`, `.java`, `.c`, `.cpp`, `.cs`, `.rb`, `.rs`, `.php`, `.kt`, `.swift`, `.sh`, `.md`, and `.txt`. If `README.md` exists it is placed first, followed by the remaining files in alphabetical order. The list of extensions can be customised from the extension's options page.
+This Chrome extension downloads the current GitHub repository as a ZIP file, extracts text-based files, and combines them into a single file. By default common programming languages are included such as `.py`, `.js`, `.ts`, `.jsx`, `.tsx`, `.go`, `.java`, `.c`, `.cpp`, `.cs`, `.rb`, `.rs`, `.php`, `.kt`, `.swift`, `.sh`, `.md`, and `.txt`. If `README.md` exists it is placed first, followed by the remaining files in alphabetical order. The list of extensions can be customised from the extension's options page. The generated text begins with the repository's full name and description.
 
 ## Custom File Extensions
 
@@ -12,8 +12,7 @@ The Options page also lets you specify glob patterns for files to omit from the 
 Paths are matched relative to the repository root and the `file:` sections in the
 output use these same relative paths.
 
-Click the extension icon while viewing a GitHub repository to download the text file. The repository is fetched from
-`https://codeload.github.com/<owner>/<repo>/zip/refs/heads/main`, and this URL is logged to the extension's service worker console.
+Click the extension icon while viewing a GitHub repository to download the text file. The repository archive is fetched from the branch shown in the URL if one is present, otherwise the repository's default branch is used. The download URL is logged to the extension's service worker console.
 
 ## Private Repositories
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -39,13 +39,29 @@ chrome.action.onClicked.addListener(async (tab: chrome.tabs.Tab) => {
     const owner = parts[0];
     const repo = parts[1];
 
-    const zipUrl = `https://codeload.github.com/${owner}/${repo}/zip/refs/heads/main`;
-    console.log('ZIP download URL:', zipUrl);
-
     const token = await getToken(tab.id!);
 
     const headers: Record<string, string> = {};
     if (token) headers['Authorization'] = `token ${token}`;
+
+    const repoInfoRes = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}`,
+      { headers }
+    );
+    if (!repoInfoRes.ok) {
+      throw new Error(
+        `Failed to fetch repo info: ${repoInfoRes.status} ${repoInfoRes.statusText}`
+      );
+    }
+    const repoInfo = await repoInfoRes.json();
+
+    let branch =
+      (parts[2] === 'tree' || parts[2] === 'blob') && parts[3]
+        ? parts[3]
+        : pageUrl.searchParams.get('ref') || repoInfo.default_branch;
+
+    const zipUrl = `https://codeload.github.com/${owner}/${repo}/zip/refs/heads/${branch}`;
+    console.log('ZIP download URL:', zipUrl);
 
     const response = await fetch(zipUrl, { headers });
     if (!response.ok) {
@@ -119,7 +135,7 @@ chrome.action.onClicked.addListener(async (tab: chrome.tabs.Tab) => {
       entries.unshift(readme);
     }
 
-    let output = `${repo}\n\n`;
+    let output = `${repoInfo.full_name}\n${repoInfo.description || ''}\n\n`;
     for (const entry of entries) {
       const text = await entry.file.async('text');
       output += `---\nfile: ${entry.path}\n---\n${text}\n\n`;

--- a/src/background.ts
+++ b/src/background.ts
@@ -55,10 +55,22 @@ chrome.action.onClicked.addListener(async (tab: chrome.tabs.Tab) => {
     }
     const repoInfo = await repoInfoRes.json();
 
-    let branch =
-      (parts[2] === 'tree' || parts[2] === 'blob') && parts[3]
-        ? parts[3]
-        : pageUrl.searchParams.get('ref') || repoInfo.default_branch;
+    let branch = pageUrl.searchParams.get('ref') || repoInfo.default_branch;
+
+    if ((parts[2] === 'tree' || parts[2] === 'blob') && parts[3]) {
+      const rest = parts.slice(3);
+      for (let i = rest.length; i >= 1; i--) {
+        const cand = rest.slice(0, i).join('/');
+        const res = await fetch(
+          `https://api.github.com/repos/${owner}/${repo}/branches/${encodeURIComponent(cand)}`,
+          { headers }
+        );
+        if (res.ok) {
+          branch = cand;
+          break;
+        }
+      }
+    }
 
     const zipUrl = `https://codeload.github.com/${owner}/${repo}/zip/refs/heads/${branch}`;
     console.log('ZIP download URL:', zipUrl);


### PR DESCRIPTION
## Summary
- fetch repo description and default branch using the GitHub API
- download from the branch in the URL when present or default branch otherwise
- prepend repository name and description to the output file
- update README to document new behaviour

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68541a872f4c8322becb6d5528285d33