### PR TITLE
Ensure README prioritized for deep directories

### DIFF
--- a/src/zipUtils.ts
+++ b/src/zipUtils.ts
@@ -54,9 +54,16 @@ export async function extractTextFromZip(
   }
 
   function collect(node: Node, prefix: string): Entry[] {
+    // Sort files alphabetically by their paths.
     const arr = [...node.files].sort((a, b) => a.path.localeCompare(b.path));
+    
+    // Construct the expected name for a README file in the current directory.
     const readmeName = prefix ? `${prefix}/README.md` : 'README.md';
+    
+    // Check if a README file exists in the current list of files.
     const idx = arr.findIndex((e) => e.path.toLowerCase() === readmeName.toLowerCase());
+    
+    // If a README file is found, move it to the front of the list to prioritize it.
     if (idx >= 0) {
       const [r] = arr.splice(idx, 1);
       arr.unshift(r);

--- a/test/extractTextFromZip.test.ts
+++ b/test/extractTextFromZip.test.ts
@@ -44,3 +44,21 @@ test('subdirectory README placed before other files in that directory', async ()
   const files = Array.from(output.matchAll(/file: ([^\n]+)/g)).map((m) => m[1]);
   assert.deepEqual(files, ['sub/README.md', 'sub/a.js', 'sub/b.js']);
 });
+
+test('deeply nested README placed before files under that directory', async () => {
+  const zip = new JSZip();
+  zip.file('repo-main/a/b/c/file.js', 'content');
+  zip.file('repo-main/a/b/README.md', 'readme b');
+  zip.file('repo-main/a/b/c/README.md', 'readme c');
+  zip.file('repo-main/README.md', 'root');
+
+  const output = await extractTextFromZip(zip, repoInfo, ['js', 'md'], []);
+
+  const files = Array.from(output.matchAll(/file: ([^\n]+)/g)).map((m) => m[1]);
+  assert.deepEqual(files, [
+    'README.md',
+    'a/b/README.md',
+    'a/b/c/README.md',
+    'a/b/c/file.js',
+  ]);
+});


### PR DESCRIPTION
## Summary
- ensure README order works recursively for arbitrarily deep directories
- test deep directory README placement

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68560b21b9ac8322b8c7ff1fa93be11f