### PR TITLE
Add file tree to repo export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Repo Single Text Exporter
 
-This Chrome extension downloads the current GitHub repository as a ZIP file, extracts text-based files, and combines them into a single file. By default common programming languages are included such as `.py`, `.js`, `.ts`, `.jsx`, `.tsx`, `.go`, `.java`, `.c`, `.cpp`, `.cs`, `.rb`, `.rs`, `.php`, `.kt`, `.swift`, `.sh`, `.md`, and `.txt`. If a `README.md` file is present it is placed first at the repository root and at the start of any subdirectories, with all other files sorted alphabetically. The list of extensions can be customised from the extension's options page. The generated text begins with the repository's full name and description.
+This Chrome extension downloads the current GitHub repository as a ZIP file, extracts text-based files, and combines them into a single file. By default common programming languages are included such as `.py`, `.js`, `.ts`, `.jsx`, `.tsx`, `.go`, `.java`, `.c`, `.cpp`, `.cs`, `.rb`, `.rs`, `.php`, `.kt`, `.swift`, `.sh`, `.md`, and `.txt`. If a `README.md` file is present it is placed first at the repository root and at the start of any subdirectories, with all other files sorted alphabetically. The list of extensions can be customised from the extension's options page. The generated text begins with the repository's full name and description, followed by a tree view of all included files.
 
 ## Custom File Extensions
 

--- a/test/extractTextFromZip.test.ts
+++ b/test/extractTextFromZip.test.ts
@@ -13,7 +13,7 @@ test('README placed first', async () => {
 
   const output = await extractTextFromZip(zip, repoInfo, ['js', 'md'], []);
 
-  const firstHeader = output.split('\n').slice(2).join('\n').match(/file: ([^\n]+)/)?.[1];
+  const firstHeader = output.match(/file: ([^\n]+)/)?.[1];
   assert.equal(firstHeader, 'README.md');
 });
 
@@ -25,11 +25,7 @@ test('root README prioritized over nested ones', async () => {
 
   const output = await extractTextFromZip(zip, repoInfo, ['md', 'c'], []);
 
-  const firstHeader = output
-    .split('\n')
-    .slice(2)
-    .join('\n')
-    .match(/file: ([^\n]+)/)?.[1];
+  const firstHeader = output.match(/file: ([^\n]+)/)?.[1];
   assert.equal(firstHeader, 'README.md');
 });
 
@@ -60,5 +56,26 @@ test('deeply nested README placed before files under that directory', async () =
     'a/b/README.md',
     'a/b/c/README.md',
     'a/b/c/file.js',
+  ]);
+});
+
+test('file tree is printed at top of output', async () => {
+  const zip = new JSZip();
+  zip.file('repo-main/src/a.js', 'aaa');
+  zip.file('repo-main/README.md', 'readme');
+
+  const output = await extractTextFromZip(zip, repoInfo, ['js', 'md'], []);
+
+  const preFile = output.split('---')[0].trim();
+  const lines = preFile
+    .split('\n')
+    .slice(2)
+    .filter((l) => l.trim() !== ''); // skip repo name/description and blanks
+
+  assert.deepEqual(lines, [
+    '.',
+    '├── README.md',
+    '└── src',
+    '    └── a.js',
   ]);
 });


### PR DESCRIPTION
## Summary
- prepend a directory tree to exported text
- update README with new behavior
- adjust tests for file tree output and add coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68560d9ea204832283ebd63fda4de31a