### PR TITLE
Add settings popup for repo extraction

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,7 @@
     "open_in_tab": true
   },
   "action": {
-    "default_title": "Export repo text"
+    "default_title": "Export repo text",
+    "default_popup": "popup.html"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "This Chrome extension downloads the current GitHub repository as a ZIP file, extracts `.py`, `.go`, `.md`, and `.txt` files, and combines them into a single text file. If a `README.md` file is present it is placed first at the repository root and at the start of any subdirectories, with all other files sorted alphabetically.",
   "type": "module",
   "scripts": {
-    "build": "esbuild src/background.ts src/options.ts --bundle --platform=browser --target=es2017 --format=esm --outdir=dist",
-    "package": "npm run build && cp manifest.json options.html dist/ && cd dist && zip -r ../extension.zip .",
+    "build": "esbuild src/background.ts src/options.ts src/popup.ts --bundle --platform=browser --target=es2017 --format=esm --outdir=dist",
+    "package": "npm run build && cp manifest.json options.html popup.html dist/ && cd dist && zip -r ../extension.zip .",
     "test": "node --loader ts-node/esm --test test/extractTextFromZip.test.ts"
   },
   "keywords": [],

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Repo Text Exporter</title>
+</head>
+<body>
+  <h1>Repository Settings</h1>
+  <label for="exts">File Extensions</label><br />
+  <textarea id="exts" rows="6" cols="30"></textarea>
+  <br />
+  <label for="exclude">Exclude Patterns</label><br />
+  <textarea id="exclude" rows="6" cols="30"></textarea>
+  <br />
+  <button id="extract">Extract</button>
+  <script type="module" src="popup.js"></script>
+</body>
+</html>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,0 +1,54 @@
+async function init() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab || !tab.url) {
+    document.body.textContent = 'Unable to determine active tab.';
+    return;
+  }
+  const url = new URL(tab.url);
+  if (url.hostname !== 'github.com') {
+    document.body.textContent = 'Not a GitHub page.';
+    return;
+  }
+  const parts = url.pathname.split('/').filter(Boolean);
+  if (parts.length < 2) {
+    document.body.textContent = 'Cannot determine repository.';
+    return;
+  }
+  const repoFull = `${parts[0]}/${parts[1]}`;
+
+  const { extensions, exclude, repoSettings } = await chrome.storage.local.get([
+    'extensions',
+    'exclude',
+    'repoSettings',
+  ]);
+
+  const extArea = document.getElementById('exts') as HTMLTextAreaElement;
+  const exArea = document.getElementById('exclude') as HTMLTextAreaElement;
+
+  const repoVals = (repoSettings && repoSettings[repoFull]) || {};
+  extArea.value =
+    repoVals.extensions ||
+    extensions ||
+    'py\njs\nts\njsx\ntsx\ngo\njava\nc\ncpp\ncs\nrb\nrs\nphp\nkt\nswift\nsh\nmd\ntxt';
+  exArea.value =
+    repoVals.exclude ||
+    exclude ||
+    '.vscode/**\n.github/**\nnode_modules/**\ndist/**\nbuild/**';
+
+  document.getElementById('extract')?.addEventListener('click', async () => {
+    const newExts = extArea.value;
+    const newEx = exArea.value;
+    const updated = { ...(repoSettings || {}) } as Record<string, any>;
+    updated[repoFull] = { extensions: newExts, exclude: newEx };
+    await chrome.storage.local.set({ repoSettings: updated });
+    await chrome.runtime.sendMessage({
+      action: 'extract',
+      tabId: tab.id,
+      extensions: newExts,
+      exclude: newEx,
+    });
+    window.close();
+  });
+}
+
+init();


### PR DESCRIPTION
## Summary
- add a popup page to configure extension and exclude patterns per repo
- store and reuse settings per repository
- trigger extraction via popup

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685611f6b6ac8322ba2d9d07c34d8df3