### PR TITLE
Add repo include globs overriding extension filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ The Options page also lets you specify glob patterns for files to omit from the 
 Paths are matched relative to the repository root and the `file:` sections in the
 output use these same relative paths.
 
+### Repository Include Patterns
+
+From the popup you can define extra glob patterns for files to include on a
+per-repository basis. Files that match these patterns are collected even if their
+extensions are not listed above. Exclude patterns still take precedence.
+
 Click the extension icon while viewing a GitHub repository to download the text file. The repository archive is fetched from the branch shown in the URL if one is present, otherwise the repository's default branch is used. Branch names containing slashes are detected correctly. The download URL is logged to the extension's service worker console.
 
 ## Private Repositories

--- a/popup.html
+++ b/popup.html
@@ -8,6 +8,10 @@
   <label for="exts">File Extensions</label><br />
   <textarea id="exts" rows="6" cols="30"></textarea>
   <br />
+  <label for="include">Additional Include Patterns</label><br />
+  <textarea id="include" rows="4" cols="30"></textarea>
+  <div><small>Matches here override the extension list but are still subject to exclude patterns.</small></div>
+  <br />
   <label for="exclude">Exclude Patterns</label><br />
   <textarea id="exclude" rows="6" cols="30"></textarea>
   <br />

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -24,6 +24,7 @@ async function init() {
 
   const extArea = document.getElementById('exts') as HTMLTextAreaElement;
   const exArea = document.getElementById('exclude') as HTMLTextAreaElement;
+  const incArea = document.getElementById('include') as HTMLTextAreaElement;
 
   const repoVals = (repoSettings && repoSettings[repoFull]) || {};
   extArea.value =
@@ -34,18 +35,21 @@ async function init() {
     repoVals.exclude ||
     exclude ||
     '.vscode/**\n.github/**\nnode_modules/**\ndist/**\nbuild/**';
+  incArea.value = repoVals.include || '';
 
   document.getElementById('extract')?.addEventListener('click', async () => {
     const newExts = extArea.value;
     const newEx = exArea.value;
+    const newInc = incArea.value;
     const updated = { ...(repoSettings || {}) } as Record<string, any>;
-    updated[repoFull] = { extensions: newExts, exclude: newEx };
+    updated[repoFull] = { extensions: newExts, exclude: newEx, include: newInc };
     await chrome.storage.local.set({ repoSettings: updated });
     await chrome.runtime.sendMessage({
       action: 'extract',
       tabId: tab.id,
       extensions: newExts,
       exclude: newEx,
+      include: newInc,
     });
     window.close();
   });

--- a/src/zipUtils.ts
+++ b/src/zipUtils.ts
@@ -10,7 +10,8 @@ export async function extractTextFromZip(
   zip: JSZip,
   repoInfo: RepoInfo,
   exts: string[],
-  excludeGlobs: string[]
+  excludeGlobs: string[],
+  includeGlobs: string[] = []
 ): Promise<string> {
   const extRegex = new RegExp(
     `\.(${exts.map((e) => e.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")).join('|')})$`,
@@ -24,8 +25,12 @@ export async function extractTextFromZip(
   zip.forEach((relativePath: string, zipEntry: JSZipObject) => {
     if (zipEntry.dir) return;
     const trimmed = relativePath.replace(/^[^/]+\//, '');
-    if (!extRegex.test(trimmed)) return;
     if (excludeGlobs.some((p) => minimatch(trimmed, p))) return;
+    if (includeGlobs.some((p) => minimatch(trimmed, p))) {
+      entries.push({ path: trimmed, file: zipEntry });
+      return;
+    }
+    if (!extRegex.test(trimmed)) return;
     entries.push({ path: trimmed, file: zipEntry });
   });
 

--- a/test/extractTextFromZip.test.ts
+++ b/test/extractTextFromZip.test.ts
@@ -79,3 +79,29 @@ test('file tree is printed at top of output', async () => {
     '    └── a.js',
   ]);
 });
+
+test('include glob overrides extension filter', async () => {
+  const zip = new JSZip();
+  zip.file('repo-main/script.special', 'aaa');
+
+  const output = await extractTextFromZip(zip, repoInfo, ['js'], [], [
+    '**/*.special',
+  ]);
+
+  assert.match(output, /file: script\.special/);
+});
+
+test('exclude globs take priority over include globs', async () => {
+  const zip = new JSZip();
+  zip.file('repo-main/src/file.txt', 'aaa');
+
+  const output = await extractTextFromZip(
+    zip,
+    repoInfo,
+    ['txt'],
+    ['src/**'],
+    ['src/file.txt']
+  );
+
+  assert.equal(/file:/.test(output), false);
+});


### PR DESCRIPTION
## Summary
- allow repository-specific include glob patterns
- prioritize exclude > include > extension filters when extracting files
- show note about priority in popup
- update README with instructions
- test new behaviour

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68561734a1708322b915e5ab84258f7c