### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run package
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: github-repo-to-single-txt-extension.zip
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
 dist/
-extension.zip
+github-repo-to-single-txt-extension.zip

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ npm install
 npm run package
 ```
 
-`npm run package` creates `extension.zip` containing the compiled background script and `manifest.json`. Load this ZIP (after extracting) as an unpacked extension in Chrome.
+`npm run package` creates `github-repo-to-single-txt-extension.zip` containing the compiled background script and `manifest.json`. Load this ZIP (after extracting) as an unpacked extension in Chrome. You can also download this pre-built ZIP from the repository's Releases page.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "esbuild src/background.ts src/options.ts src/popup.ts --bundle --platform=browser --target=es2017 --format=esm --outdir=dist",
-    "package": "npm run build && cp manifest.json dist/ && cp -r html dist/ && cp -r icons dist/ && cd dist && zip -r ../extension.zip .",
+    "package": "npm run build && cp manifest.json dist/ && cp -r html dist/ && cp -r icons dist/ && cd dist && zip -r ../github-repo-to-single-txt-extension.zip .",
     "test": "node --loader ts-node/esm --test test/extractTextFromZip.test.ts"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- update packaging script to create github-repo-to-single-txt-extension.zip
- ignore the new ZIP name
- add GitHub workflow to build and upload release assets when a tag like `1.0.0` is pushed
- mention the releases page download in README

## Testing
- `npm test`
- `npm run package`

------
https://chatgpt.com/codex/tasks/task_e_685634aae7fc8322a32e377d0ecf0431