### PR TITLE
release.yml: Add permissions section for GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,4 +22,3 @@ jobs:
       - uses: softprops/action-gh-release@v1
         with:
           files: github-repo-to-single-txt-extension.zip
-


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration in `.github/workflows/release.yml`. The changes focus on improving permissions and streamlining the release process.

Workflow updates:

* Added `permissions` block with `contents: write` to ensure the workflow has the necessary permissions to modify repository contents during the release process. (`[.github/workflows/release.ymlR8-R10](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R8-R10)`)
* Removed an unnecessary trailing line in the `jobs` section, simplifying the configuration. (`[.github/workflows/release.ymlL22](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L22)`)