### PR TITLE
Add chunk size option and progress indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Use the Options page to specify which file extensions should be collected when e
 ### Exclude Files
 
 The Options page also lets you specify glob patterns for files to omit from the export. By default `.vscode/**`, `.github/**`, `node_modules/**`, `dist/**`, and `build/**` are excluded. Enter one pattern per line using [minimatch](https://github.com/isaacs/minimatch) syntax to customise the list.
+You can also configure the maximum size of each output file in megabytes. The default is 3MB.
 Paths are matched relative to the repository root and the `file:` sections in the
 output use these same relative paths.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Use the Options page to specify which file extensions should be collected when e
 ### Exclude Files
 
 The Options page also lets you specify glob patterns for files to omit from the export. By default `.vscode/**`, `.github/**`, `node_modules/**`, `dist/**`, and `build/**` are excluded. Enter one pattern per line using [minimatch](https://github.com/isaacs/minimatch) syntax to customise the list.
-You can also configure the maximum size of each output file in megabytes. The default is 3MB.
+You can also configure the maximum size of each output file in megabytes. The default is 2MB.
 Paths are matched relative to the repository root and the `file:` sections in the
 output use these same relative paths.
 

--- a/html/options.html
+++ b/html/options.html
@@ -20,6 +20,9 @@
       <code>build/**</code> are skipped.
     </p>
     <textarea id="exclude" rows="6" cols="30"></textarea>
+    <h1>Chunk Size (MB)</h1>
+    <p>Maximum size of each output file. Default is 3MB.</p>
+    <input id="chunkSizeMB" type="number" min="1" />
     <br />
     <button id="save">Save</button>
     <script type="module" src="../options.js"></script>

--- a/html/options.html
+++ b/html/options.html
@@ -21,7 +21,7 @@
     </p>
     <textarea id="exclude" rows="6" cols="30"></textarea>
     <h1>Chunk Size (MB)</h1>
-    <p>Maximum size of each output file. Default is 3MB.</p>
+    <p>Maximum size of each output file. Default is 2MB.</p>
     <input id="chunkSizeMB" type="number" min="1" />
     <br />
     <button id="save">Save</button>

--- a/html/popup.html
+++ b/html/popup.html
@@ -20,6 +20,8 @@
     <label for="exclude">Exclude Patterns</label><br />
     <textarea id="exclude" rows="6" cols="30"></textarea>
     <br />
+    <div id="progress"></div>
+    <br />
     <button id="extract">Extract</button>
     <script type="module" src="../popup.js"></script>
   </body>

--- a/src/background.ts
+++ b/src/background.ts
@@ -26,7 +26,7 @@ async function runExtraction(
   try {
     const { chunkSizeMB } = await chrome.storage.local.get('chunkSizeMB');
     const chunkSizeBytes =
-      (parseFloat(chunkSizeMB) || 3) * 1024 * 1024;
+      (parseFloat(chunkSizeMB) || 2) * 1024 * 1024;
 
     await chrome.storage.local.set({
       exportProgress: { status: 'working', progress: 0 },

--- a/src/options.ts
+++ b/src/options.ts
@@ -13,7 +13,7 @@ async function loadOptions() {
     exclude ||
     '.vscode/**\n.github/**\nnode_modules/**\ndist/**\nbuild/**';
   const chunkInput = document.getElementById('chunkSizeMB') as HTMLInputElement;
-  chunkInput.value = String(chunkSizeMB || 3);
+  chunkInput.value = String(chunkSizeMB || 2);
 }
 
 async function saveOptions() {
@@ -23,7 +23,7 @@ async function saveOptions() {
   await chrome.storage.local.set({
     extensions: extArea.value,
     exclude: exArea.value,
-    chunkSizeMB: parseFloat(chunkInput.value) || 3,
+    chunkSizeMB: parseFloat(chunkInput.value) || 2,
   });
   alert('Saved');
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,7 +1,8 @@
 async function loadOptions() {
-  const { extensions, exclude } = await chrome.storage.local.get([
+  const { extensions, exclude, chunkSizeMB } = await chrome.storage.local.get([
     'extensions',
     'exclude',
+    'chunkSizeMB',
   ]);
   const extArea = document.getElementById('exts') as HTMLTextAreaElement;
   extArea.value =
@@ -11,12 +12,19 @@ async function loadOptions() {
   exArea.value =
     exclude ||
     '.vscode/**\n.github/**\nnode_modules/**\ndist/**\nbuild/**';
+  const chunkInput = document.getElementById('chunkSizeMB') as HTMLInputElement;
+  chunkInput.value = String(chunkSizeMB || 3);
 }
 
 async function saveOptions() {
   const extArea = document.getElementById('exts') as HTMLTextAreaElement;
   const exArea = document.getElementById('exclude') as HTMLTextAreaElement;
-  await chrome.storage.local.set({ extensions: extArea.value, exclude: exArea.value });
+  const chunkInput = document.getElementById('chunkSizeMB') as HTMLInputElement;
+  await chrome.storage.local.set({
+    extensions: extArea.value,
+    exclude: exArea.value,
+    chunkSizeMB: parseFloat(chunkInput.value) || 3,
+  });
   alert('Saved');
 }
 

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -25,6 +25,32 @@ async function init() {
   const extArea = document.getElementById('exts') as HTMLTextAreaElement;
   const exArea = document.getElementById('exclude') as HTMLTextAreaElement;
   const incArea = document.getElementById('include') as HTMLTextAreaElement;
+  const progressDiv = document.getElementById('progress') as HTMLDivElement;
+
+  function displayProgress(data: any) {
+    if (!data) {
+      progressDiv.textContent = '';
+      return;
+    }
+    if (data.status === 'working') {
+      progressDiv.textContent = `Processing... ${Math.round(
+        (data.progress || 0) * 100
+      )}%`;
+    } else if (data.status === 'done') {
+      progressDiv.textContent = 'Completed';
+    } else {
+      progressDiv.textContent = '';
+    }
+  }
+
+  const stored = await chrome.storage.local.get('exportProgress');
+  displayProgress(stored.exportProgress);
+
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local' && changes.exportProgress) {
+      displayProgress(changes.exportProgress.newValue);
+    }
+  });
 
   const repoVals = (repoSettings && repoSettings[repoFull]) || {};
   extArea.value =
@@ -51,6 +77,7 @@ async function init() {
       exclude: newEx,
       include: newInc,
     });
+    progressDiv.textContent = 'Processing... 0%';
     window.close();
   });
 }

--- a/src/zipUtils.ts
+++ b/src/zipUtils.ts
@@ -19,7 +19,7 @@ export async function* extractTextFromZipChunked(
   exts: string[],
   excludeGlobs: string[],
   includeGlobs: string[] = [],
-  maxChunkSizeBytes: number = 5 * 1024 * 1024 // 5MB default
+  maxChunkSizeBytes: number = 2 * 1024 * 1024 // 2MB default
 ): AsyncGenerator<FileChunk, void, unknown> {
   const extRegex = new RegExp(
     `\.(${exts.map((e) => e.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")).join('|')})$`,


### PR DESCRIPTION
## Summary
- make chunk size configurable in Options (default 3MB)
- show export progress in the popup while files are processed
- track progress state in storage

## Testing
- `npm ci`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68654051b3988322a250d667004d6a50